### PR TITLE
Resolves #5: Fix the Maven config for SonarCloud coverage.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <sonar.projectKey>codepenguin-org_vehicle-restriction-testing-example</sonar.projectKey>
         <sonar.organization>codepenguin-org</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <mockito.version>3.6.28</mockito.version>
     </properties>
     <dependencies>
         <dependency>
@@ -55,6 +56,39 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -95,6 +129,12 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.6</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/org/codepenguin/example/tdd/vehicle_restriction/domain/*</exclude>
+                        <exclude>**/org/codepenguin/example/tdd/vehicle_restriction/dto/*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/java/org/codepenguin/example/tdd/vehicle_restriction/ApplicationTests.java
+++ b/src/test/java/org/codepenguin/example/tdd/vehicle_restriction/ApplicationTests.java
@@ -24,29 +24,30 @@
 
 package org.codepenguin.example.tdd.vehicle_restriction;
 
-import org.codepenguin.example.tdd.vehicle_restriction.service.VehicleRestrictionService;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.SpringApplication;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.commons.lang.math.NumberUtils.INTEGER_ONE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 /**
- * Functional tests for {@link Application}.
+ * Unit tests for {@link Application}.
  *
  * @author Jorge Garcia
  * @version 0.0.1
  * @since 11
  */
-@SpringBootTest
 class ApplicationTests {
 
-    @Autowired
-    private VehicleRestrictionService service;
-
     @Test
-    void contextLoads() {
-        assertThat(service).isNotNull();
-    }
+    void givenNoParametersWhenMainThenDoNothing() {
+        try (var mockStatic = mockStatic(SpringApplication.class)) {
+            Application.main(new String[]{});
 
+            mockStatic.verify(times(INTEGER_ONE), () -> SpringApplication.run(eq(Application.class), any()));
+        }
+    }
 }


### PR DESCRIPTION
- Fix the Maven configuration for exclude DTO's and Domain packages.
- Fix the `ApplicationTests` class, making it a unit test class.